### PR TITLE
Fell back to using the enum values in the field `choices` if the UI labels are not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Django's migration system. **Please note**, to make the underlying `Enum`
 and `EnumItem` compatible with Django's migration system, you _must_
 use the sub-classes available from `enum_field.Enum` and 
 `enum_field.EnumItem` and *not* from the `python-enumeration` project.
+
+
+# Changelog
+
+## Version 1.0 Beta 1 (unreleased)
+
+- Fell back to using the enum values in the field `choices` if the UI labels
+  are not set.
+- **Backwardly incompatible:** Dropped ability to set custom field choices.

--- a/enum_field.py
+++ b/enum_field.py
@@ -7,22 +7,21 @@ from enumeration import EnumItem as PythonEnumItem
 
 class EnumField(CharField):
     def __init__(self, enum, *args, **kwargs):
-        longest_enum_value = max(len(enum_value) for enum_value in enum)
         self.enum = enum
+        self.enum_items_by_values = enum.get_items_by_values()
 
         if enum.has_ui_labels:
             choices = enum.get_ui_labels()
         else:
-            choices = list(zip(enum, enum))
+            choices = [(i, v) for v, i in self.enum_items_by_values.items()]
 
+        longest_enum_value = max(len(enum_value) for enum_value in enum)
         super(EnumField, self).__init__(
             max_length=longest_enum_value,
             choices=choices,
             *args,
             **kwargs
         )
-
-        self.enum_items_by_values = enum.get_items_by_values()
 
     def deconstruct(self):
         name, path, args, kwargs = super(EnumField, self).deconstruct()

--- a/enum_field.py
+++ b/enum_field.py
@@ -11,14 +11,15 @@ class EnumField(CharField):
         self.enum = enum
 
         if enum.has_ui_labels:
-            assert 'choices' not in kwargs, \
-                'The enum has UI labels set which precludes specifying choices'
             choices = enum.get_ui_labels()
         else:
-            choices = kwargs.pop('choices', [])
+            choices = list(zip(enum, enum))
 
         super(EnumField, self).__init__(
-            max_length=longest_enum_value, choices=choices, *args, **kwargs
+            max_length=longest_enum_value,
+            choices=choices,
+            *args,
+            **kwargs
         )
 
         self.enum_items_by_values = enum.get_items_by_values()
@@ -26,8 +27,7 @@ class EnumField(CharField):
     def deconstruct(self):
         name, path, args, kwargs = super(EnumField, self).deconstruct()
         args.insert(0, self.enum)
-        if self.enum.has_ui_labels:
-            del kwargs['choices']
+        del kwargs['choices']
         del kwargs['max_length']
         return name, path, args, kwargs
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(
-    version='0.2',
+    version='1.0b1',
     name='django-enum-field',
     install_requires=[
         'python-enumeration',

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from enum_field import Enum, EnumItem, EnumField, EnumFieldValidationError
 from nose.tools import assert_raises
 from nose.tools import eq_
 from nose.tools import ok_
+
+from enum_field import Enum, EnumItem, EnumField, EnumFieldValidationError
 
 
 class TestEnumDjangoSpecifics(object):
@@ -111,68 +112,34 @@ class TestEnumField(object):
         enum_value = self.enum_field.from_db_value(None, None, None, None)
         eq_(None, enum_value)
 
-    def test_choices_for_ui_labels(self):
-        """
-        When the UI labels are set for the Enum, the "choices" attribute is
-        automatically set from the Enum.
-        """
+    def test_enum_with_ui_labels(self):
         self.CLOTHES_SIZE_ENUM.set_ui_labels(self.items_ui_labels)
 
         enum_field = EnumField(self.CLOTHES_SIZE_ENUM)
 
         eq_(enum_field.choices, self.CLOTHES_SIZE_ENUM.get_ui_labels())
 
-    def test_choices_for_ui_labels_with_choices(self):
-        """
-        If choices is specified when UI labels have already been set an
-        AssertionError is raised.
-        """
+    def test_enum_without_ui_labels(self):
+        expected_choices = [(v, v) for v in self.CLOTHES_SIZE_ENUM]
+        eq_(expected_choices, self.enum_field.choices)
 
-        self.CLOTHES_SIZE_ENUM.set_ui_labels(self.items_ui_labels)
-
-        with assert_raises(AssertionError):
+    def test_custom_choices(self):
+        with assert_raises(TypeError):
             EnumField(
                 self.CLOTHES_SIZE_ENUM,
                 choices=(('a', 'Apple'), ('b', 'Ball')),
             )
 
-    def test_choices_for_unset_ui_labels_no_choices(self):
-        """
-        When no UI labels have been set and no "choices" argument is passed,
-        the "choices" attribute is not set.
-        """
-
-        eq_(self.enum_field.choices, [])
-
-    def test_choices_for_unset_ui_labels_with_choices(self):
-        """
-        When no UI labels have been set but a "choices" argument is passed,
-        the "choices" attribute is set to the choices passed in.
-        """
-
-        choices = (('a', 'Apple'), ('b', 'Ball'))
-        enum_field = EnumField(self.CLOTHES_SIZE_ENUM, choices=choices)
-
-        eq_(enum_field.choices, choices)
-
-    def test_deconstruction_with_no_ui_labels(self):
-        self._check_enum_field_deconstruction(self.enum_field)
-
-    def test_deconstruction_with_ui_labels(self):
-        self.CLOTHES_SIZE_ENUM.set_ui_labels(self.items_ui_labels)
-        enum_field = EnumField(self.CLOTHES_SIZE_ENUM)
-        self._check_enum_field_deconstruction(enum_field)
-
-    def _check_enum_field_deconstruction(self, enum_field):
-        field_deconstructed = enum_field.deconstruct()
+    def test_deconstruction(self):
+        field_deconstructed = self.enum_field.deconstruct()
         _, class_name, args, kwargs = field_deconstructed
+
         eq_('enum_field.EnumField', class_name)
         eq_(1, len(args))
-        eq_(self.CLOTHES_SIZE_ENUM, args[0])
-        eq_({}, kwargs)
+        eq_(self.enum_field.enum, args[0])
+        eq_(0, len(kwargs))
 
 
-from enum_field import Enum, EnumField
 CLOTHING_SIZES = Enum(
     ('xs', 'EXTRA_SMALL'),
     ('s', 'SMALL'),

--- a/tests/test_enum_field.py
+++ b/tests/test_enum_field.py
@@ -120,7 +120,8 @@ class TestEnumField(object):
         eq_(enum_field.choices, self.CLOTHES_SIZE_ENUM.get_ui_labels())
 
     def test_enum_without_ui_labels(self):
-        expected_choices = [(v, v) for v in self.CLOTHES_SIZE_ENUM]
+        enum_items_by_values = self.CLOTHES_SIZE_ENUM.get_items_by_values()
+        expected_choices = [(i, v) for v, i in enum_items_by_values.items()]
         eq_(expected_choices, self.enum_field.choices)
 
     def test_custom_choices(self):


### PR DESCRIPTION
Was also forced to drop ability to set custom field choices because it wouldn't be possible to "deconstruct" the field (without a major rework of the field) -- Plus, I couldn't see how this feature would actually be useful.

CIT-162